### PR TITLE
Bug 1161143 - Remove unused android-resources.mn files from b2g branding

### DIFF
--- a/b2g/branding/official/android-resources.mn
+++ b/b2g/branding/official/android-resources.mn
@@ -1,1 +1,0 @@
-b2g/branding/official/content/splash.png

--- a/b2g/branding/unofficial/android-resources.mn
+++ b/b2g/branding/unofficial/android-resources.mn
@@ -1,1 +1,0 @@
-b2g/branding/unofficial/content/splash.png


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1161143
